### PR TITLE
fix; Character 레벨업 메서드

### DIFF
--- a/TextRPG/Program/Character.cs
+++ b/TextRPG/Program/Character.cs
@@ -240,8 +240,8 @@ namespace TextRPG.CharacterManagement
                     ApplyBenefits(); // 레벨업 시 스탯 증가
                     MaxEXP = 15 * Level; //MaxEXP 갱신
                     //레벨업 시 클래스이름-랭크 증가(직급 상승)
-                    ClassName = Enum.GetName(typeof(Ranks), Level);
-                    Console.WriteLine($"{Name}이(가) {ClassName}(으)로 승진했습니다! 현재 레벨: {Level}");
+                    Rank = Enum.GetName(typeof(Ranks), Level);
+                    Console.WriteLine($"{Name}이(가) {Rank}(으)로 승진했습니다! 현재 레벨: {Level}");
                 }
             }
         }

--- a/TextRPG/Program/Monster.cs
+++ b/TextRPG/Program/Monster.cs
@@ -320,7 +320,8 @@ namespace TextRPG.MonsterManagement
                 Console.WriteLine("[내 정보]");
                 Console.WriteLine($"Lv.{character.Level} {character.Name} ({character.ClassName})");
                 Console.WriteLine($"HP {character.Health}/{character.MaxHealth}\n");
-                
+
+                character.AssignSkills();
                 character.ShowSkillList();
 
                 Console.WriteLine("[몬스터 목록]");


### PR DESCRIPTION
캐릭터의 레벨업 시, Rank가 아닌 ClassName이 재설정 되던 문제 수정(이제 과장이자 대리가 되지 않습니다)
Monster.cs >>현재 오류가 생긴 놈입니다 즉시 멀쩡한 놈으로 들고올테니 기다려주세요